### PR TITLE
Switch PI to M_PI to support STRICT_R_HEADERS

### DIFF
--- a/src/flm_stat.cpp
+++ b/src/flm_stat.cpp
@@ -162,7 +162,7 @@ double flm_stat(arma::mat E, int p, arma::vec Adot_vec, bool constant = true) {
   double c = 1;
   if (constant) {
 
-    c = (2 * std::pow(PI, 0.5 * (p + q) - 1)) /
+    c = (2 * std::pow(M_PI, 0.5 * (p + q) - 1)) /
       (q * R::gammafn(0.5 * p) * R::gammafn(0.5 * q) * n * n);
 
   }
@@ -225,7 +225,7 @@ arma::vec Adot(arma::mat X) {
   arma::vec Adot_vec = arma::zeros(n * (n - 1) / 2 + 1);
 
   // The first element of Adot_vec is the common diagonal element
-  Adot_vec[0] = PI * (n + 1);
+  Adot_vec[0] = M_PI * (n + 1);
 
   // Loop on the rest of the elements are the lower triangle matrix of Adot
   for (arma::uword i = 2; i <= n; i++) {
@@ -239,7 +239,7 @@ arma::vec Adot(arma::mat X) {
         if ((i == r) | (j == r)) {
 
           // Sum variable
-          sum_r += PI;
+          sum_r += M_PI;
 
         } else {
 


### PR DESCRIPTION
Dear Eduardo, dear goffda team,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history.

Your package uses (in one file) PI (instead of the standard C define M_PI, or e.g. the newer Armadillo constant arma::datum::pi) and PI goes away when we set STRICT_R_HEADERS (as a #define in a header or source file, a -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do). We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

This very simple PR changes PI to M_PI. Your code will then work with and without STRICT_R_HEADERS (as M_PI is an old define from C). PI only works when STRICT_R_HEADERS is not defined.

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.